### PR TITLE
varnish 5.2 + modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
-FROM phusion/baseimage
+# 16.04 xenial
+FROM phusion/baseimage:0.10.2
 MAINTAINER Adrian Gschwend <adrian.gschwend@zazuko.com>
 
 RUN apt-get install -y apt-transport-https 
-RUN curl https://repo.varnish-cache.org/GPG-key.txt | apt-key add -
-RUN echo "deb https://repo.varnish-cache.org/ubuntu/ trusty varnish-4.1" >> /etc/apt/sources.list.d/varnish-cache.list
+RUN curl -L https://packagecloud.io/varnishcache/varnish5/gpgkey | apt-key add -
+RUN echo "deb https://packagecloud.io/varnishcache/varnish5/ubuntu/ xenial main" >> /etc/apt/sources.list.d/varnish-cache.list
 RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
-RUN apt-get -y install varnish
+RUN apt-get -y install varnish=5.2.1-1~xenial varnish-dev=5.2.1-1~xenial
+
+## compile varnish modules
+RUN apt-get install -y make autoconf-archive git libtool m4 automake python-docutils
+WORKDIR /tmp
+RUN git clone https://github.com/varnish/varnish-modules && cd varnish-modules && git checkout 0.15.0
+WORKDIR /tmp/varnish-modules
+RUN ./bootstrap && \
+  ./configure && \
+  make && \
+  make install
 
 RUN mkdir /etc/service/varnishd
 ADD run.sh /etc/service/varnishd/run

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-# Varnish Cache Docker image with latest stable version (4.1.x) [![Build Status](https://travis-ci.org/zazukoians/docker-varnish.svg)](https://travis-ci.org/zazukoians/docker-varnish)[![](https://imagelayers.io/badge/zazukoians/varnish:latest.svg)](https://imagelayers.io/?images=zazukoians/varnish:latest 'Get your own badge on imagelayers.io')
+# Varnish Cache Docker image [![Build Status](https://travis-ci.org/zazukoians/docker-varnish.svg)](https://travis-ci.org/zazukoians/docker-varnish)[![](https://imagelayers.io/badge/zazukoians/varnish:latest.svg)](https://imagelayers.io/?images=zazukoians/varnish:latest)
 
-This Docker image ships [Varnish Cache](https://www.varnish-cache.org/), a HTTP accelerator designed for content-heavy dynamic web sites as well as heavily consumed APIs by Varnish Software. It is based on [Baseimage-docker](https://github.com/phusion/baseimage-docker), which is a Docker optimized version of Ubuntu LTS.
+This Docker image ships [Varnish Cache](https://www.varnish-cache.org/), an HTTP accelerator designed for content-heavy dynamic web sites as well as heavily consumed APIs by Varnish Software. It is based on [Baseimage-docker](https://github.com/phusion/baseimage-docker), which is a Docker optimized version of Ubuntu 16.04.
 
 If you have any problems with this image please report issues on Github. Pull requests are also welcome.
 
-Varnish is pulled from the offical Ubuntu LTS package repository by varnish-cache.org. This allows us to use the latest stable version 4.1.x of Varnish Cache.
-
-We originally planned to build it on Alpine Linux to get a smaller image but had no luck with the build process there. We might re-try that another time.
+The image includes [varnish-modules](https://github.com/varnish/varnish-modules/tree/0.15.0).
 
 ### Varnish environment variables
 
-You can change its behaviour by changing the following environment variables:
+You can change its behavior by changing the following environment variables:
 
     ENV VCL_CONFIG      /etc/varnish/default.vcl
     ENV CACHE_SIZE      256m
@@ -18,30 +16,14 @@ You can change its behaviour by changing the following environment variables:
 
 Default parameters were taken from the [The Varnish Tutorial](https://www.varnish-cache.org/docs/4.1/index.html). The default configuration file is shipped by Varnish Cache.
 
-### Use the pre built image
+### Basing your Varnish image on this project
 
-The pre built image can be downloaded using Docker.
+We do not recommend using this image as-is.
 
-    $ docker pull zazukoians/varnish
+Here is how you should use it instead:
 
+```
+FROM zazukoians/varnish:<choose a version>
 
-### Build the docker image by yourself
-
-You can also adjust and build the image according to your needs. Just clone the repository and then execute the build command.
-
-    $ docker build -t zazukoians/varnish .
-
-
-### Start the container
-
-    $ sudo docker run -i -d -p 80 zazukoians/varnish
-
-Note that this alone won't be very useful as the default configuration points to a backend server on localhost port 8080. This will not work as there is no such server running in this image. Instead combine this image with an instance of an application container.
-
-_TODO add an example_
-
-#### Start the container and keep control
-The command above starts the container and runs it in foreground. You can get a console in this image by executing
-
-    $ docker run -ti -p 443 - zazukoians/varnish /bin/bash
-
+COPY your-varnish-config-file.vcl /etc/varnish/default.vcl
+```


### PR DESCRIPTION
Here is an update to the ubuntu version used by the image, to varnish from 4.1.x to 5.2, and it includes varnish-modules to make it possible to cache POST requests when needed.